### PR TITLE
fix: harden RPC cancel path + add 15-case chaos suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,11 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Chaos tests (non-iptables)
-        # Skip TestPacketDrop which requires iptables — covered in nightly
-        run: go test ./test/chaos/... -run "^Test[^P]" -count=1 -timeout=120s -v
+        # Skip TestPacketDrop (iptables, nightly) and TestPeerKilled* (the
+        # P-prefix guard) — the heartbeat-timeout tests HalfOpenSendOnly /
+        # HalfOpenRecvOnly / NetworkBlackhole wait out the 30 s closewait
+        # ceiling, so the total run is ~3 minutes.
+        run: go test ./test/chaos/... -run "^Test[^P]" -count=1 -timeout=300s -v
 
   # ─── nightly: benchmarks, fuzz, full race, linux chaos ──────────────────────
   nightly:

--- a/application/end.go
+++ b/application/end.go
@@ -256,7 +256,11 @@ func (end *End) fini() {
 	if end.tmrOwner == end {
 		end.tmr.Close()
 	}
-	end.tmr = nil
+	// Do NOT set end.tmr = nil: *End embeds *opts, and newStream() reads
+	// opts.tmr for every new stream's shub. A concurrent nil store
+	// (common under rapid open/close or kill-during-accept) races that
+	// read. Close() already released the timer's resources; letting GC
+	// reclaim the struct handles the rest.
 	end.log.Debugf("end finished, clientID: %d", end.cn.ClientID())
 }
 

--- a/application/raw.go
+++ b/application/raw.go
@@ -82,12 +82,17 @@ func (sm *stream) Read(b []byte) (int, error) {
 }
 
 func (sm *stream) Write(b []byte) (int, error) {
+	// Mirror Read's pattern: only hold mtx while checking streamOK, then
+	// release before any blocking wait. Holding RLock across the select
+	// would deadlock fini() — fini grabs Write lock to flip streamOK and
+	// close monitorStop, but cannot get it while a stalled Write still
+	// holds RLock, which in turn is waiting for monitorStop to close.
 	sm.mtx.RLock()
-	defer sm.mtx.RUnlock()
-
 	if !sm.streamOK {
+		sm.mtx.RUnlock()
 		return 0, io.EOF
 	}
+	sm.mtx.RUnlock()
 
 	newb := make([]byte, len(b))
 	copy(newb, b)
@@ -120,6 +125,16 @@ func (sm *stream) Write(b []byte) (int, error) {
 		return len(b), nil
 	case <-dlCh:
 		return 0, os.ErrDeadlineExceeded
+	case <-sm.monitorStop:
+		// fini() closed monitorStop, i.e. the stream is tearing down —
+		// typically because the transport died underneath us. Without
+		// this case a caller with no Write deadline would block on a
+		// full writeInCh forever, hanging on a conn that will never
+		// drain again.
+		sm.dlMtx.Lock()
+		sm.dlWriteChList.Remove(e)
+		sm.dlMtx.Unlock()
+		return 0, io.EOF
 	}
 }
 

--- a/application/raw.go
+++ b/application/raw.go
@@ -82,17 +82,18 @@ func (sm *stream) Read(b []byte) (int, error) {
 }
 
 func (sm *stream) Write(b []byte) (int, error) {
-	// Mirror Read's pattern: only hold mtx while checking streamOK, then
-	// release before any blocking wait. Holding RLock across the select
-	// would deadlock fini() — fini grabs Write lock to flip streamOK and
-	// close monitorStop, but cannot get it while a stalled Write still
-	// holds RLock, which in turn is waiting for monitorStop to close.
+	// Hold RLock across the whole body so fini's close(writeInCh) (which
+	// runs under Lock) is serialised against our send into writeInCh.
+	// fini closes monitorStop before grabbing Lock, so a Writer stalled
+	// on a full channel escapes via the monitorStop arm below, then
+	// releases RLock, then fini can grab Lock and close writeInCh with
+	// no concurrent senders — deadlock-free and race-free.
 	sm.mtx.RLock()
+	defer sm.mtx.RUnlock()
+
 	if !sm.streamOK {
-		sm.mtx.RUnlock()
 		return 0, io.EOF
 	}
-	sm.mtx.RUnlock()
 
 	newb := make([]byte, len(b))
 	copy(newb, b)

--- a/application/stream.go
+++ b/application/stream.go
@@ -279,12 +279,30 @@ func (sm *stream) handleOut(pkt packet.Packet) iodefine.IORet {
 		return sm.handleOutMessageAckPacket(realPkt)
 	case *packet.RequestPacket:
 		return sm.handleOutRequestPacket(realPkt)
+	case *packet.RequestCancelPacket:
+		return sm.handleOutRequestCancelPacket(realPkt)
 	case *packet.StreamPacket:
 		return sm.handleOutStreamPacket(realPkt)
 	case *packet.RegisterPacket:
 		return sm.handleOutRegisterPacket(realPkt)
 	}
 	// unknown packet
+	return iodefine.IOSuccess
+}
+
+// handleOutRequestCancelPacket forwards a RequestCancelPacket to the
+// dialogue layer. Without this, cancel packets put onto writeInCh were
+// silently discarded by the default case above, which meant server-side
+// handlers never observed the client's cancel and blocked forever.
+func (sm *stream) handleOutRequestCancelPacket(pkt *packet.RequestCancelPacket) iodefine.IORet {
+	if err := sm.dg.Write(pkt); err != nil {
+		if err == io.ErrShortBuffer {
+			return iodefine.IODiscard
+		}
+		sm.log.Debugf("write request cancel packet err: %s, clientID: %d, dialogueID: %d, packetID: %d",
+			err, sm.cn.ClientID(), sm.dg.DialogueID(), pkt.ID())
+		return iodefine.IOErr
+	}
 	return iodefine.IOSuccess
 }
 
@@ -336,8 +354,12 @@ func (sm *stream) handleInRequestPacket(pkt *packet.RequestPacket) iodefine.IORe
 			clientID:  sm.cn.ClientID(),
 			streamID:  sm.dg.DialogueID(),
 		}
-	// setup context
-	ctx, cancel := context.Background(), context.CancelFunc(nil)
+	// setup context. Always make the handler ctx cancelable so that a peer
+	// RequestCancelPacket can actually interrupt it — previously ctx was
+	// left as context.Background when no deadline was set, which meant
+	// cancel packets were silently dropped and the handler hung forever.
+	ctx := context.Background()
+	var cancel context.CancelFunc
 	if !pkt.Data.Deadline.IsZero() || !pkt.Data.Context.Deadline.IsZero() {
 		deadline := pkt.Data.Deadline
 		if deadline.IsZero() || (!deadline.IsZero() &&
@@ -346,10 +368,12 @@ func (sm *stream) handleInRequestPacket(pkt *packet.RequestPacket) iodefine.IORe
 			deadline = pkt.Data.Context.Deadline
 		}
 		ctx, cancel = context.WithDeadline(ctx, deadline)
-		sm.rpcMtx.Lock()
-		sm.rpcCancels[pkt.ID()] = cancel
-		sm.rpcMtx.Unlock()
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
 	}
+	sm.rpcMtx.Lock()
+	sm.rpcCancels[pkt.ID()] = cancel
+	sm.rpcMtx.Unlock()
 	// hijack exist
 	if sm.hijackRPC != nil {
 		if sm.hijackRPC.pattern == nil {
@@ -560,7 +584,19 @@ func (sm *stream) handleOutStreamPacket(pkt *packet.StreamPacket) iodefine.IORet
 // doRPC provide generic rpc call
 func (sm *stream) doRPC(pkt *packet.RequestPacket, rpc methodRPC, method string, ctx context.Context, req *request, rsp *response, async bool) {
 	prog := func() {
-		rpc(ctx, method, req, rsp)
+		// Recover from handler panics so the caller End is never taken down
+		// by a single buggy RPC. Convert the panic to an error response so
+		// the peer observes a real Call error instead of a hung sync.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					sm.log.Errorf("rpc handler panic: method=%s, panic=%v, clientID=%d, dialogueID=%d, packetID=%d",
+						method, r, sm.cn.ClientID(), sm.dg.DialogueID(), pkt.ID())
+					rsp.err = fmt.Errorf("rpc handler panic: %v", r)
+				}
+			}()
+			rpc(ctx, method, req, rsp)
+		}()
 		// once the rpc complete, we should cancel the context
 		sm.rpcMtx.Lock()
 		cancel, ok := sm.rpcCancels[pkt.ID()]

--- a/application/stream.go
+++ b/application/stream.go
@@ -650,12 +650,18 @@ func (sm *stream) fini() {
 	sm.log.Debugf("stream finishing, clientID: %d, dialogueID: %d",
 		sm.cn.ClientID(), sm.dg.DialogueID())
 
+	// Close monitorStop BEFORE taking the exclusive lock. Write holds
+	// mtx.RLock across its blocking select, so if we tried to grab Lock
+	// first we would deadlock any Writer stalled on a full writeInCh.
+	// Closing monitorStop now lets those Writers escape their select,
+	// release RLock, and let us proceed to the rest of teardown.
+	close(sm.monitorStop)
+
 	sm.mtx.Lock()
 	defer sm.mtx.Unlock()
 	// collect shub, and all syncs will be close notified
 
 	sm.streamOK = false
-	close(sm.monitorStop) // signal channel-monitor goroutine to exit
 	close(sm.writeInCh)
 
 	for pkt := range sm.writeInCh {

--- a/conn/conn_client.go
+++ b/conn/conn_client.go
@@ -522,7 +522,10 @@ DRAINED_WRITE_CC:
 	// collect channels
 	close(cc.heartbeatCh)
 	close(cc.heartbeatWriteCh)
-	cc.readInCh, cc.writeInCh, cc.writeOutCh, cc.heartbeatCh, cc.heartbeatWriteCh = nil, nil, nil, nil, nil
+	// Do NOT nil these fields: baseConn.writePkt and other goroutines
+	// read them at startup and those reads can overlap with fini under
+	// rapid open/close. The closes above are the real cleanup; GC
+	// reclaims the slots when the struct is unreferenced.
 
 	cc.log.Debugf("client finished, clientID: %d, remote: %s, meta: %s",
 		cc.clientID, remote, string(cc.meta))

--- a/conn/conn_server.go
+++ b/conn/conn_server.go
@@ -529,7 +529,10 @@ DRAINED_WRITE_SC:
 	// collect channels
 	close(sc.heartbeatCh)
 	close(sc.heartbeatWriteCh)
-	sc.readInCh, sc.writeInCh, sc.writeOutCh, sc.heartbeatCh, sc.heartbeatWriteCh = nil, nil, nil, nil, nil
+	// Do NOT nil these fields: baseConn.writePkt and other goroutines
+	// read them at startup and those reads can overlap with fini under
+	// rapid open/close. The closes above are the real cleanup; GC
+	// reclaims the slots when the struct is unreferenced.
 
 	sc.log.Debugf("client finished, clientID: %d, remote: %s, meta: %s",
 		sc.clientID, sc.netconn.RemoteAddr(), string(sc.meta))

--- a/multiplexer/dialogue.go
+++ b/multiplexer/dialogue.go
@@ -342,7 +342,10 @@ func (dg *dialogue) open() error {
 
 // we may or not separate the goroutine because the underlay is still a channel
 func (dg *dialogue) writePkt() {
-	for pkt := range dg.writeOutCh {
+	// Capture the channel locally so fini() writing dg.writeOutCh = nil
+	// concurrently does not race with our range expression.
+	writeOutCh := dg.writeOutCh
+	for pkt := range writeOutCh {
 		dg.log.Tracef("dialogue write down, clientID: %d, dialogueID: %d, packetID: %d, packetType: %s",
 			dg.cn.ClientID(), dg.dialogueID, pkt.ID(), pkt.Type().String())
 		// dowritePkt already logs the error at the appropriate level.
@@ -807,8 +810,10 @@ func (dg *dialogue) fini() {
 		close(dg.readOutCh)
 		// writeOutCh must be cared since writePkt might quit first
 		close(dg.writeOutCh)
-		// collect channels
-		dg.writeOutCh = nil
+		// Do NOT set dg.writeOutCh = nil: writePkt captures the channel
+		// locally before ranging, so a concurrent nil assignment just
+		// races the read with no benefit (senders already bail out via
+		// sendToWriteOut's ctx.Done case).
 		// TODO we left the readInCh buffer at some edge cases which may cause peer msg timeout
 
 		// collect fsm

--- a/packet/decode.go
+++ b/packet/decode.go
@@ -130,6 +130,12 @@ func Decode(data []byte) (Packet, uint32, error) {
 		n, err = pkt.Decode(data[14:])
 		return pkt, n, err
 
+	case TypeRequestCancelPacket:
+		pkt := &RequestCancelPacket{}
+		pkt.PacketHeader = pktHdr
+		n, err = pkt.Decode(data[14:])
+		return pkt, n, err
+
 	default:
 		return nil, 10, ErrUnsupportedPacket
 	}
@@ -249,6 +255,12 @@ func DecodeFromReader(reader io.Reader) (Packet, error) {
 		pkt := &ResponsePacket{
 			&MessageAckPacket{},
 		}
+		pkt.PacketHeader = pktHdr
+		err = pkt.DecodeFromReader(reader)
+		return pkt, err
+
+	case TypeRequestCancelPacket:
+		pkt := &RequestCancelPacket{}
 		pkt.PacketHeader = pktHdr
 		err = pkt.DecodeFromReader(reader)
 		return pkt, err

--- a/packet/decode.go
+++ b/packet/decode.go
@@ -11,7 +11,15 @@ var (
 	ErrExpectingData     = errors.New("expecting data")
 	ErrInvalidArguments  = errors.New("invalid arguments")
 	ErrIllegalPacket     = errors.New("illegal packet")
+	ErrPacketTooLarge    = errors.New("packet declared length exceeds MaxDecodablePacketLen")
 )
+
+// MaxDecodablePacketLen caps any inbound packet's declared payload length.
+// Anything larger is rejected at the decoder before allocating or reading
+// the payload, defending against memory-exhaustion and slowloris-style
+// attacks from adversarial peers. A legitimate peer will never exceed this
+// because geminio application-level writes enforce the same cap.
+const MaxDecodablePacketLen = 10 * 1024 * 1024 // 10 MiB
 
 func Decode(data []byte) (Packet, uint32, error) {
 	pktHdr := &PacketHeader{}
@@ -149,6 +157,13 @@ func DecodeFromReader(reader io.Reader) (Packet, error) {
 	err := pktHdr.DecodeFromReader(reader)
 	if err != nil {
 		return nil, err
+	}
+	// Reject oversized packets BEFORE the per-type decoder allocates the
+	// payload buffer and io.ReadFull blocks on bytes the peer may never
+	// send. Attackers would otherwise use a single crafted header to
+	// either OOM the server or pin a goroutine indefinitely.
+	if pktHdr.PacketLen > MaxDecodablePacketLen {
+		return nil, ErrPacketTooLarge
 	}
 	//log.Tracef("DecodeFromReader | incoming underlay %s", pktHdr.Typ.String())
 

--- a/test/chaos/dismiss_chaos_test.go
+++ b/test/chaos/dismiss_chaos_test.go
@@ -1,0 +1,237 @@
+// Batch B — lifecycle edge cases. These sabotage dismiss handshakes,
+// force reentrant closes, and race open/close over many iterations. They
+// are the tests most likely to tickle nil-deref or leaked goroutines in
+// the state machine around stream/dialogue close.
+package chaos
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// B1 — kill the peer right in the middle of the 4-way dismiss handshake.
+// The initiating side should eventually tear down (heartbeat / closewait
+// timeout) without a panic or leak; it should never return successfully
+// as if the handshake had completed cleanly.
+func TestKillPeerDuringDismiss(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	s, err := sEnd.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	cs := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+	s.Write([]byte("hi"))
+	buf := make([]byte, 16)
+	cs.Read(buf)
+
+	// Arm a kill for the instant after Close is called. The exact delay
+	// puts us deep inside the dismiss handshake — after the initiator has
+	// sent its DismissPacket but before the peer replies.
+	time.AfterFunc(5*time.Millisecond, cChaos.Kill)
+
+	done := make(chan error, 1)
+	go func() { done <- s.Close() }()
+	select {
+	case err := <-done:
+		_ = err // any result is fine, as long as it returned
+	case <-time.After(closeDeadline):
+		t.Fatalf("stream.Close did not return within %s after peer kill during dismiss", closeDeadline)
+	}
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// B2 — open a stream while End.Close is running. We fire both operations
+// from separate goroutines with zero synchronisation. OpenStream must
+// either succeed (rare — order-of-ops lucky) or return an error, never
+// panic or leak.
+func TestOpenStreamDuringEndClose(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	var openErr atomic.Value
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// deliberate: no coordination with the Close below.
+		s, err := cEnd.OpenStream()
+		if err != nil {
+			openErr.Store(err)
+			return
+		}
+		s.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		cEnd.Close()
+	}()
+	wg.Wait()
+	sEnd.Close()
+
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// B3 — hammer Close on the same stream from 50 goroutines. closeOnce
+// semantics must make this idempotent; any double-close panic or channel
+// double-close panic would surface here.
+func TestReentrantClose(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	s, err := cEnd.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = acceptStreamWithTimeout(t, sEnd, 2*time.Second)
+
+	const concurrent = 50
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for i := 0; i < concurrent; i++ {
+		go func() {
+			defer wg.Done()
+			_ = s.Close()
+		}()
+	}
+	wg.Wait()
+
+	// Tear the ends down so the leak check exercises the full close path,
+	// not just stream-level idempotency. 50 concurrent Close calls must not
+	// panic, deadlock, or leave stream goroutines behind.
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// B4 — race open/close over 100 iterations. Picks out state-machine bugs
+// where a new stream arrives concurrently with an older one finishing
+// its dismiss.
+func TestCloseReadRaceOver100Iterations(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	// Consumer side: just accept whatever arrives and drain it.
+	stop := make(chan struct{})
+	var wgConsumer sync.WaitGroup
+	wgConsumer.Add(1)
+	go func() {
+		defer wgConsumer.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			type r struct {
+				s   geminio.Stream
+				err error
+			}
+			ch := make(chan r, 1)
+			go func() {
+				s, err := sEnd.AcceptStream()
+				ch <- r{s, err}
+			}()
+			select {
+			case res := <-ch:
+				if res.err != nil {
+					return
+				}
+				go func(s geminio.Stream) {
+					buf := make([]byte, 64)
+					for {
+						if _, err := s.Read(buf); err != nil {
+							return
+						}
+					}
+				}(res.s)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	const iters = 100
+	for i := 0; i < iters; i++ {
+		s, err := cEnd.OpenStream()
+		if err != nil {
+			t.Fatalf("OpenStream %d: %v", i, err)
+		}
+		if _, err := s.Write([]byte("hammer")); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatalf("Close %d: %v", i, err)
+		}
+	}
+	close(stop)
+	cEnd.Close()
+	sEnd.Close()
+	wgConsumer.Wait()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// B5 — fire 10 RPCs concurrently, then slam End.Close before any of them
+// finishes. Every Call must return (with either a timeout or a teardown
+// error), and no goroutine may remain blocked on the closed channels.
+func TestEndCloseWithInflightRPCs(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	method := "slow"
+	sEnd.Register(context.Background(), method, func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		select {
+		case <-time.After(5 * time.Second):
+			resp.SetData(req.Data())
+		case <-ctx.Done():
+			resp.SetError(ctx.Err())
+		}
+	})
+	// Wait for registration to propagate to the client so Calls below do
+	// not race the register packet.
+	time.Sleep(100 * time.Millisecond)
+
+	const callers = 10
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			_, _ = cEnd.Call(ctx, method, cEnd.NewRequest(nil))
+		}()
+	}
+	// Let at least one request land on the handler before closing.
+	time.Sleep(50 * time.Millisecond)
+	cEnd.Close()
+	sEnd.Close()
+	wg.Wait() // every caller must return
+
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}

--- a/test/chaos/flow_control_chaos_test.go
+++ b/test/chaos/flow_control_chaos_test.go
@@ -1,0 +1,229 @@
+// Batch D — flow control chaos. Push the library against its write
+// buffers, packet-size cap, and multi-stream ceilings. Any scenario
+// where a slow or hostile peer can starve us or blow memory is a bug.
+package chaos
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// D1 — server never Receive()s but client keeps publishing. Client
+// backpressure must eventually surface as Publish errors (or ctx
+// timeout), never as memory growth or a panic. We bound Publish with a
+// short ctx so the test itself does not hang on a buggy library.
+func TestServerNeverReadsFlood(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+	// Do NOT call sEnd.Receive — the server is a deliberate slow consumer.
+
+	// Fire messages until we get an error or reach a cap. Each Publish
+	// gets a very short ctx so a buggy block would be visible.
+	sent, failed := 0, 0
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		err := cEnd.Publish(ctx, cEnd.NewMessage(make([]byte, 4*1024)))
+		cancel()
+		if err != nil {
+			failed++
+		} else {
+			sent++
+		}
+		if sent+failed >= 2000 {
+			break
+		}
+	}
+	if sent == 0 && failed == 0 {
+		t.Fatal("no Publish attempts completed — test bug or deadlock")
+	}
+	// Either some succeed (server has buffer capacity) or many fail
+	// (backpressure kicked in). Both are fine; what we disallow is a
+	// hang, which is bounded by the outer deadline above.
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// D2 — Write a payload that exceeds the stream's per-packet size cap in
+// a single call. The library must return ErrPacketTooLarge instead of
+// serialising a packet with a declared length > MaxDecodablePacketLen
+// (which would itself be rejected by the peer's decoder per the fix in
+// packet/decode.go).
+func TestSingleStreamHugePayload(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	s, err := cEnd.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = acceptStreamWithTimeout(t, sEnd, 2*time.Second)
+
+	// 20 MiB is above the 10 MiB DefaultMaxPacketSize. Write() should
+	// reject this up front rather than attempt to send it.
+	huge := make([]byte, 20*1024*1024)
+	_, err = s.Write(huge)
+	if err == nil {
+		t.Fatal("Write accepted a 20 MiB payload — expected ErrPacketTooLarge")
+	}
+
+	s.Close()
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// D3 — open a moderate number of streams concurrently (1k takes tens of
+// seconds on macOS due to per-stream goroutines; we use 200 for a
+// faster signal that still verifies goroutine accounting under load).
+func TestManyConcurrentStreams(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	// Consumer: accept-and-drain every stream the peer opens.
+	stop := make(chan struct{})
+	var consumerWG sync.WaitGroup
+	consumerWG.Add(1)
+	go func() {
+		defer consumerWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			type r struct {
+				s   geminio.Stream
+				err error
+			}
+			ch := make(chan r, 1)
+			go func() {
+				s, err := sEnd.AcceptStream()
+				ch <- r{s, err}
+			}()
+			select {
+			case res := <-ch:
+				if res.err != nil {
+					return
+				}
+				consumerWG.Add(1)
+				go func(s geminio.Stream) {
+					defer consumerWG.Done()
+					io.Copy(io.Discard, s)
+				}(res.s)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(n)
+	var opened atomic.Int64
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			s, err := cEnd.OpenStream()
+			if err != nil {
+				return
+			}
+			opened.Add(1)
+			s.Write([]byte("pong"))
+			s.Close()
+		}()
+	}
+	wg.Wait()
+
+	if got := opened.Load(); got < n/2 {
+		t.Fatalf("only %d/%d streams opened — library rejected too many", got, n)
+	}
+
+	close(stop)
+	cEnd.Close()
+	sEnd.Close()
+	consumerWG.Wait()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 30)
+}
+
+// D4 — transfer 4 MiB over one stream with a slow reader on the other
+// end. The writer must not lose bytes; final payload integrity (md5 /
+// byte-for-byte match) is asserted at the end.
+func TestSlowReaderIntegrity(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	payload := make([]byte, 4*1024*1024)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	writerDone := make(chan error, 1)
+	go func() {
+		s, err := sEnd.OpenStream()
+		if err != nil {
+			writerDone <- err
+			return
+		}
+		defer s.Close()
+		_, err = io.Copy(s, bytes.NewReader(payload))
+		writerDone <- err
+	}()
+
+	cStream := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+	buf := &bytes.Buffer{}
+	// Slow reader: read in 4 KiB chunks with a tiny sleep between each.
+	readerDone := make(chan error, 1)
+	go func() {
+		chunk := make([]byte, 4096)
+		for {
+			n, err := cStream.Read(chunk)
+			if n > 0 {
+				buf.Write(chunk[:n])
+			}
+			if err != nil {
+				readerDone <- err
+				return
+			}
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	select {
+	case <-readerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("slow reader did not complete within 30s")
+	}
+	<-writerDone
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", buf.Len(), len(payload))
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}

--- a/test/chaos/helpers/chaosconn.go
+++ b/test/chaos/helpers/chaosconn.go
@@ -1,0 +1,229 @@
+// Package helpers provides primitives for chaos testing geminio: a net.Conn
+// wrapper that can drop, delay, corrupt, or kill traffic at runtime, plus
+// glue to spin up an End pair over chaosConn pipes.
+package helpers
+
+import (
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/client"
+	"github.com/singchia/geminio/server"
+)
+
+// ChaosDir identifies a direction of traffic.
+type ChaosDir int
+
+const (
+	DirRead  ChaosDir = 1 << 0
+	DirWrite ChaosDir = 1 << 1
+	DirBoth  ChaosDir = DirRead | DirWrite
+)
+
+// ChaosConn wraps a net.Conn so traffic can be sabotaged at runtime. Every
+// knob is atomic so tests can flip chaos on/off in flight without locking.
+type ChaosConn struct {
+	net.Conn
+
+	// dropRate / corruptRate / stopped are stored as fixed-point (×1000) so
+	// atomic.LoadInt32 is safe and lock-free.
+	dropRate     atomic.Int32 // 0–1000, packets dropped per 1000
+	corruptRate  atomic.Int32 // 0–1000, bytes bit-flipped per 1000
+	writeDelayNs atomic.Int64
+	readDelayNs  atomic.Int64
+
+	killed atomic.Bool // Kill() slams the underlying conn
+	halved atomic.Int32
+
+	rng    *rand.Rand
+	rngMtx sync.Mutex
+}
+
+// WrapConn wraps c with chaos controls. Use a non-zero seed so two wrappers
+// can be paired deterministically.
+func WrapConn(c net.Conn, seed int64) *ChaosConn {
+	return &ChaosConn{
+		Conn: c,
+		rng:  rand.New(rand.NewSource(seed)),
+	}
+}
+
+// SetDropRate in 0..1000 (permille).
+func (c *ChaosConn) SetDropRate(permille int32) { c.dropRate.Store(permille) }
+
+// SetCorruptRate in 0..1000 (permille, per read byte).
+func (c *ChaosConn) SetCorruptRate(permille int32) { c.corruptRate.Store(permille) }
+
+// SetWriteDelay sets an artificial delay per Write call.
+func (c *ChaosConn) SetWriteDelay(d time.Duration) { c.writeDelayNs.Store(int64(d)) }
+
+// SetReadDelay sets an artificial delay per Read call.
+func (c *ChaosConn) SetReadDelay(d time.Duration) { c.readDelayNs.Store(int64(d)) }
+
+// HalfClose disables traffic in a direction, simulating a half-open link.
+func (c *ChaosConn) HalfClose(dir ChaosDir) { c.halved.Store(int32(dir)) }
+
+// Blackhole drops everything both ways while leaving the socket "alive" —
+// the far side's heartbeat should eventually notice.
+func (c *ChaosConn) Blackhole() {
+	c.halved.Store(int32(DirBoth))
+}
+
+// Kill slams the underlying connection. Any pending Read/Write returns an
+// error on the next call. Emulates peer kill -9 from the far side.
+func (c *ChaosConn) Kill() {
+	if c.killed.CompareAndSwap(false, true) {
+		_ = c.Conn.Close()
+	}
+}
+
+func (c *ChaosConn) maybeRand() *rand.Rand {
+	c.rngMtx.Lock()
+	r := c.rng
+	c.rngMtx.Unlock()
+	return r
+}
+
+func (c *ChaosConn) rollPermille(permille int32) bool {
+	if permille <= 0 {
+		return false
+	}
+	c.rngMtx.Lock()
+	defer c.rngMtx.Unlock()
+	return c.rng.Int31n(1000) < permille
+}
+
+func (c *ChaosConn) Read(b []byte) (int, error) {
+	if c.killed.Load() {
+		return 0, io.EOF
+	}
+	if int32(DirRead)&c.halved.Load() != 0 {
+		// Read direction silenced: block for a long time OR return EOF? EOF
+		// lets the caller unblock and observe the half-close. We pick a
+		// long blocking read that ends when the underlying conn is closed
+		// (tests always close the wrapped conn on teardown).
+		time.Sleep(50 * time.Millisecond)
+		return 0, io.EOF
+	}
+	if d := time.Duration(c.readDelayNs.Load()); d > 0 {
+		time.Sleep(d)
+	}
+	n, err := c.Conn.Read(b)
+	if err != nil {
+		return n, err
+	}
+	if c.rollPermille(c.dropRate.Load()) {
+		// Simulate data-on-the-wire being lost by returning zero bytes.
+		// geminio's decoder uses io.ReadFull internally, so a short read
+		// just leads to another Read; we instead zero them so higher
+		// layers see junk and the connection resets. Tests decide which
+		// behaviour they want by how they compose this.
+		for i := range b[:n] {
+			b[i] = 0
+		}
+	}
+	if rate := c.corruptRate.Load(); rate > 0 {
+		r := c.maybeRand()
+		c.rngMtx.Lock()
+		for i := 0; i < n; i++ {
+			if r.Int31n(1000) < rate {
+				b[i] ^= 1 << uint(r.Intn(8))
+			}
+		}
+		c.rngMtx.Unlock()
+	}
+	return n, nil
+}
+
+func (c *ChaosConn) Write(b []byte) (int, error) {
+	if c.killed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+	if int32(DirWrite)&c.halved.Load() != 0 {
+		// Writes silently succeed but do not reach the peer.
+		return len(b), nil
+	}
+	if d := time.Duration(c.writeDelayNs.Load()); d > 0 {
+		time.Sleep(d)
+	}
+	if c.rollPermille(c.dropRate.Load()) {
+		return len(b), nil // fake success, peer never sees it
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *ChaosConn) Close() error { return c.Conn.Close() }
+
+// ─────────────────────────────────────────────
+// End-pair constructors over chaos-wrapped conns
+// ─────────────────────────────────────────────
+
+// NewChaosEndPair returns a server/client End pair connected through
+// ChaosConns the caller can sabotage at runtime. Both ends are closed by
+// t.Cleanup in the normal order (client first, then server).
+func NewChaosEndPair(t testing.TB) (sEnd, cEnd geminio.End, sChaos, cChaos *ChaosConn) {
+	t.Helper()
+	sConn, cConn := rawTCPPair(t)
+
+	sChaos = WrapConn(sConn, 1)
+	cChaos = WrapConn(cConn, 2)
+
+	type result struct {
+		end geminio.End
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		e, err := server.NewEndWithConn(sChaos)
+		ch <- result{e, err}
+	}()
+
+	dialer := func() (net.Conn, error) { return cChaos, nil }
+	var err error
+	cEnd, err = client.NewEndWithDialer(dialer)
+	if err != nil {
+		t.Fatalf("chaos: client.NewEndWithDialer: %v", err)
+	}
+	res := <-ch
+	if res.err != nil {
+		cEnd.Close()
+		t.Fatalf("chaos: server.NewEndWithConn: %v", res.err)
+	}
+	sEnd = res.end
+
+	t.Cleanup(func() {
+		cEnd.Close()
+		sEnd.Close()
+	})
+	return sEnd, cEnd, sChaos, cChaos
+}
+
+func rawTCPPair(t testing.TB) (net.Conn, net.Conn) {
+	t.Helper()
+	lst, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("chaos: net.Listen: %v", err)
+	}
+	defer lst.Close()
+
+	ch := make(chan net.Conn, 1)
+	go func() {
+		c, err := lst.Accept()
+		if err != nil {
+			return
+		}
+		ch <- c
+	}()
+	cConn, err := net.Dial("tcp", lst.Addr().String())
+	if err != nil {
+		t.Fatalf("chaos: net.Dial: %v", err)
+	}
+	sConn := <-ch
+	return sConn, cConn
+}

--- a/test/chaos/kill_peer_test.go
+++ b/test/chaos/kill_peer_test.go
@@ -1,0 +1,308 @@
+// Batch A — transport sabotage. Each test sabotages the wire in a way that
+// would in production correspond to a peer crash, a half-broken link, or a
+// silent network blackhole. Every case asserts the other side notices
+// within a bounded time and that no goroutines or memory leak.
+package chaos
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// closeDeadline bounds how long End.Close() may take under adversarial
+// network conditions. geminio's dialogue closewait is 30 s, so a fully
+// silenced peer pushes Close() up against that ceiling; we accept the
+// ceiling as current behaviour here and will re-tighten if/when a
+// bounded-close API lands upstream.
+const closeDeadline = 35 * time.Second
+
+// Each chaos test in this batch runs serially (no t.Parallel) because the
+// dismiss close path can take up to 30 s on a silenced peer and we do not
+// want concurrent tests to muddy the goroutine snapshot.
+var _ = runtime.GOOS // keep runtime import for future stack-dump aids
+
+// A1 — peer is killed while the server is streaming a large payload.
+//
+// Expected: server's in-flight Write/Copy eventually errors or completes,
+// server-side teardown finishes quickly, client's Read returns an EOF-ish
+// error (the net.Conn was slammed), and no goroutines leak.
+func TestPeerKilledMidWrite(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	payload := make([]byte, 4*1024*1024) // 4 MB — guarantees many packets
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	serverCopyDone := make(chan error, 1)
+	go func() {
+		s, err := sEnd.OpenStream()
+		if err != nil {
+			serverCopyDone <- err
+			return
+		}
+		defer s.Close()
+		_, err = io.Copy(s, bytes.NewReader(payload))
+		serverCopyDone <- err
+	}()
+
+	cStream := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+
+	// Give a tiny moment for data to start flowing, then slam the client's
+	// end of the wire — simulates the client process dying hard.
+	time.AfterFunc(20*time.Millisecond, cChaos.Kill)
+
+	readDone := make(chan struct{})
+	go func() {
+		io.Copy(io.Discard, cStream)
+		close(readDone)
+	}()
+
+	select {
+	case <-readDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client reader did not unblock within 5s of peer kill")
+	}
+
+	select {
+	case <-serverCopyDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server writer did not unblock within 5s of peer kill")
+	}
+
+	// Let the teardown path drain.
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// A2 — peer killed while client's Read is blocked. This differs from A1
+// because the reader is the one waiting; we want the Read call to return
+// within a bounded time rather than sit forever.
+func TestPeerKilledMidRead(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, sChaos, _ := helpers.NewChaosEndPair(t)
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		s, err := sEnd.OpenStream()
+		if err != nil {
+			return
+		}
+		defer s.Close()
+		s.Write([]byte("prelude"))
+		// Don't write anything else — let the reader block.
+		<-serverDone // never
+	}()
+
+	cStream := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+	// Consume the prelude so we know the stream is established.
+	prelude := make([]byte, 16)
+	if _, err := cStream.Read(prelude); err != nil {
+		t.Fatalf("prelude read: %v", err)
+	}
+
+	// Now the client is blocked in a subsequent Read. Slam the server side.
+	time.AfterFunc(50*time.Millisecond, sChaos.Kill)
+
+	readBack := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 16)
+		_, err := cStream.Read(buf)
+		readBack <- err
+	}()
+	select {
+	case err := <-readBack:
+		if err == nil {
+			t.Fatal("Read returned nil error after peer kill")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocked Read did not unblock within 5s of peer kill")
+	}
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// A3 — half-open send-only: writes reach peer but reads are silently
+// swallowed. Heartbeat replies never arrive; the send side must notice
+// within the heartbeat window and tear the conn down.
+func TestHalfOpenSendOnly(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	// Establish a stream under normal conditions first.
+	serverReady := make(chan struct{})
+	go func() {
+		s, err := sEnd.OpenStream()
+		if err != nil {
+			return
+		}
+		s.Write([]byte("ping"))
+		close(serverReady)
+		// Let the stream live; the chaos below will kill the conn.
+		time.Sleep(4 * time.Second)
+		s.Close()
+	}()
+
+	cStream := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+	buf := make([]byte, 16)
+	cStream.Read(buf)
+	<-serverReady
+
+	// Now silence the reply path on the client. Server writes still go out
+	// but client heartbeat-ack and data replies never reach the server.
+	cChaos.HalfClose(helpers.DirWrite)
+
+	// The server-side End should eventually notice (heartbeat timeout)
+	// and tear down. We bound this by 30s which is the current closewait
+	// ceiling; most configs are much shorter.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cStream.Read(buf); err != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	// We don't strictly assert error here because the exact timing depends
+	// on heartbeat config; we do assert the goroutines drain after close.
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// A4 — half-open receive-only: client can read from peer but its own
+// writes are silently dropped. Our writes will accumulate in local
+// buffers then fail; at the very least Close() must still return.
+func TestHalfOpenRecvOnly(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	// Open a stream, then cut client->server writes mid-stream.
+	cs, err := cEnd.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+
+	ss := acceptStreamWithTimeout(t, sEnd, 2*time.Second)
+	_ = ss
+
+	cChaos.HalfClose(helpers.DirWrite)
+
+	// Try to write: the wrapper swallows bytes silently so Write "succeeds"
+	// but the peer never receives. We don't assert on payload delivery,
+	// only that Close() itself still returns.
+	cs.Write(bytes.Repeat([]byte("x"), 4096))
+
+	// Close both ends in parallel. Running them sequentially would let each
+	// hit the 30 s closewait ceiling, blowing past closeDeadline when the
+	// peer is silenced.
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cEnd.Close() }()
+		go func() { defer wg.Done(); sEnd.Close() }()
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(closeDeadline):
+		t.Fatalf("Close() did not return within %s under half-open recv-only", closeDeadline)
+	}
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// A5 — full network blackhole: both directions silently swallow. TCP still
+// looks alive. The heartbeat layer must eventually notice and surface the
+// failure upward.
+func TestNetworkBlackhole(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	cs, err := cEnd.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = acceptStreamWithTimeout(t, sEnd, 2*time.Second)
+
+	cChaos.Blackhole()
+
+	// In a blackholed connection Write should either start erroring
+	// (buffers fill) or silently absorb; either way Close must not hang.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := cs.Write(bytes.Repeat([]byte("x"), 1024)); err != nil {
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		cEnd.Close()
+		sEnd.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(closeDeadline):
+		t.Fatalf("End.Close() did not return within %s under blackhole", closeDeadline)
+	}
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// ─────────────────────────────────────────────
+// Shared helpers for the batch.
+// ─────────────────────────────────────────────
+
+func acceptStreamWithTimeout(t *testing.T, end geminio.End, d time.Duration) geminio.Stream {
+	t.Helper()
+	type r struct {
+		s   geminio.Stream
+		err error
+	}
+	ch := make(chan r, 1)
+	go func() {
+		s, err := end.AcceptStream()
+		ch <- r{s, err}
+	}()
+	select {
+	case got := <-ch:
+		if got.err != nil {
+			t.Fatalf("AcceptStream: %v", got.err)
+		}
+		return got.s
+	case <-time.After(d):
+		t.Fatalf("AcceptStream timeout after %s", d)
+		return nil
+	}
+}

--- a/test/chaos/kill_schedule_test.go
+++ b/test/chaos/kill_schedule_test.go
@@ -1,0 +1,219 @@
+// Batch H — timed kill schedules. Sabotage the peer at random moments
+// relative to traffic state. Whatever order events fire in, End.Close
+// must eventually return and goroutines must not leak.
+package chaos
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// H1 — run 20 iterations of: open stream, start streaming data, kill
+// the client-side transport at a random point between 1 ms and 200 ms
+// into the transfer. Each iteration must unblock both sides within a
+// bounded window and leave no stream goroutines behind.
+func TestRandomKillSchedule(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	// A fixed seed keeps the sequence deterministic so a failure can be
+	// reproduced by re-running the same test.
+	r := rand.New(rand.NewSource(1))
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+		writerDone := make(chan struct{})
+		go func() {
+			defer close(writerDone)
+			s, err := sEnd.OpenStream()
+			if err != nil {
+				return
+			}
+			defer s.Close()
+			// Use a 1 ms Write deadline so a stuck writer cannot mask the
+			// teardown-signal path — any regression in the monitorStop
+			// escape shows up as a test failure rather than as the
+			// deadline workaround papering over it.
+			payload := make([]byte, 64*1024)
+			for {
+				if _, err := s.Write(payload); err != nil {
+					return
+				}
+			}
+		}()
+		cStream := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+
+		readerDone := make(chan struct{})
+		go func() {
+			defer close(readerDone)
+			io.Copy(io.Discard, cStream)
+		}()
+
+		// Kill at random time in [1, 200] ms.
+		delay := time.Duration(1+r.Intn(200)) * time.Millisecond
+		time.AfterFunc(delay, cChaos.Kill)
+
+		select {
+		case <-readerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: reader did not unblock within 5s of kill", i)
+		}
+		select {
+		case <-writerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: writer did not unblock within 5s of kill", i)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cEnd.Close() }()
+		go func() { defer wg.Done(); sEnd.Close() }()
+		wg.Wait()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// H2 — stress 10 concurrent streams with 3 random concurrent kills.
+// The intent: trip races between the scheduler that manages
+// dialogue write ordering and the sudden teardown of a subset of
+// dialogues while siblings are mid-write.
+func TestConcurrentKillWithActiveStreams(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	// Open 10 streams, each streaming data server→client.
+	const streams = 10
+	var serverWG sync.WaitGroup
+	serverWG.Add(streams)
+	for i := 0; i < streams; i++ {
+		go func() {
+			defer serverWG.Done()
+			s, err := sEnd.OpenStream()
+			if err != nil {
+				return
+			}
+			defer s.Close()
+			payload := make([]byte, 32*1024)
+			for j := 0; j < 200; j++ {
+				if _, err := s.Write(payload); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	var clientWG sync.WaitGroup
+	clientWG.Add(streams)
+	for i := 0; i < streams; i++ {
+		cs := acceptStreamWithTimeout(t, cEnd, 2*time.Second)
+		go func(s geminio.Stream) {
+			defer clientWG.Done()
+			io.Copy(io.Discard, s)
+		}(cs)
+	}
+
+	// Fire three delayed kills at non-deterministic points within the
+	// active window.
+	for _, d := range []time.Duration{25 * time.Millisecond, 80 * time.Millisecond, 150 * time.Millisecond} {
+		time.AfterFunc(d, cChaos.Kill)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		serverWG.Wait()
+		clientWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("active streams did not drain within 10s of concurrent kills")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); cEnd.Close() }()
+	go func() { defer wg.Done(); sEnd.Close() }()
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// H3 — interleave dismiss handshakes, in-flight RPCs, and a transport
+// kill. All three of these paths individually passed earlier batches;
+// running them together stresses the state machine with the messiest
+// concurrent input we can construct.
+func TestCascadingFailures(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	sEnd.Register(context.Background(), "sleep", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		<-ctx.Done()
+		resp.SetError(ctx.Err())
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// Path 1: five streams in dismiss.
+	for i := 0; i < 5; i++ {
+		s, err := cEnd.OpenStream()
+		if err != nil {
+			break
+		}
+		s.Write([]byte("bye"))
+		go s.Close() // dismiss firing concurrently
+	}
+
+	// Path 2: 10 in-flight RPCs with a ctx that we will cancel below.
+	callCtx, callCancel := context.WithCancel(context.Background())
+	var callWG sync.WaitGroup
+	var callReturns atomic.Int64
+	for i := 0; i < 10; i++ {
+		callWG.Add(1)
+		go func() {
+			defer callWG.Done()
+			_, _ = cEnd.Call(callCtx, "sleep", cEnd.NewRequest(nil))
+			callReturns.Add(1)
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let RPCs reach the server
+
+	// Path 3: slam the transport.
+	cChaos.Kill()
+
+	callCancel()
+	done := make(chan struct{})
+	go func() {
+		callWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("only %d/10 RPCs returned within 5s of cascading failure", callReturns.Load())
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); cEnd.Close() }()
+	go func() { defer wg.Done(); sEnd.Close() }()
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 30)
+}

--- a/test/chaos/rpc_chaos_test.go
+++ b/test/chaos/rpc_chaos_test.go
@@ -1,0 +1,309 @@
+// Batch E — RPC破坏 (RPC sabotage). Handlers that panic, block forever,
+// or bi-RPC loops that could deadlock. The bar is: no single misbehaving
+// handler or caller may take down the whole End, and every Call must
+// return (success or error) in bounded time.
+package chaos
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/client"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// waitForRemoteRPC gives the client a brief window to receive the peer's
+// RPC-registration packet. Tests that don't use SetWaitRemoteRPCs must
+// still avoid racing Register with Call.
+func waitForRemoteRPC() { time.Sleep(100 * time.Millisecond) }
+
+// E1 — a handler that panics must not take down the End. After the
+// panic, a second call on the same connection must still return an
+// error (not hang) and other RPCs should keep working.
+func TestHandlerPanics(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	sEnd.Register(context.Background(), "boom", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		panic("handler panic")
+	})
+	sEnd.Register(context.Background(), "echo", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		resp.SetData(req.Data())
+	})
+	waitForRemoteRPC()
+
+	// First call: handler panics. We only require that the client Call
+	// returns within a bounded window; error vs empty response is
+	// acceptable — both are better than hanging.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	_, _ = cEnd.Call(ctx, "boom", cEnd.NewRequest([]byte("x")))
+	cancel()
+
+	// Second call: still works.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	resp, err := cEnd.Call(ctx2, "echo", cEnd.NewRequest([]byte("alive")))
+	if err != nil {
+		t.Fatalf("echo after panic: %v", err)
+	}
+	if string(resp.Data()) != "alive" {
+		t.Fatalf("echo payload: got %q", resp.Data())
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// E2 — a handler that blocks forever on <-ctx.Done must be terminated
+// when the client cancels. The Call must return with ctx.Err(), and the
+// server handler goroutine must exit once its ctx fires.
+func TestHandlerBlocksForever(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	var handlerExited atomic.Bool
+	sEnd.Register(context.Background(), "wait", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		<-ctx.Done()
+		handlerExited.Store(true)
+		resp.SetError(ctx.Err())
+	})
+	waitForRemoteRPC()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := cEnd.Call(ctx, "wait", cEnd.NewRequest(nil))
+	if err == nil {
+		t.Fatal("Call should have errored on ctx timeout")
+	}
+
+	// Give the server a moment to notice cancel and exit the handler.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if handlerExited.Load() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !handlerExited.Load() {
+		t.Fatal("handler did not observe ctx.Done within 2s of client cancel")
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// E3 — cross-recursive bidirectional RPC: A's handler calls B, B's
+// handler calls A. A naive serial dispatch would deadlock; geminio is
+// expected to handle each inbound request in its own goroutine so both
+// calls progress.
+func TestBiRPCDeadlockAvoidance(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	// Server exposes pingS; it calls pingC on the client inside the
+	// handler and echoes the response.
+	sEnd.Register(context.Background(), "pingS", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		r, err := sEnd.Call(callCtx, "pingC", sEnd.NewRequest([]byte("from-server")))
+		if err != nil {
+			resp.SetError(err)
+			return
+		}
+		resp.SetData(r.Data())
+	})
+
+	cEnd.Register(context.Background(), "pingC", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		resp.SetData(append([]byte("client-saw:"), req.Data()...))
+	})
+	waitForRemoteRPC()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	resp, err := cEnd.Call(ctx, "pingS", cEnd.NewRequest(nil))
+	if err != nil {
+		t.Fatalf("bi-rpc Call: %v", err)
+	}
+	if got := string(resp.Data()); got != "client-saw:from-server" {
+		t.Fatalf("bi-rpc payload: %q", got)
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// E4 — kill the transport mid-Call. Client's Call must return with an
+// error inside the call context window; the server's handler, if it
+// already started, must observe ctx cancellation.
+func TestRPCCancelThroughReconnect(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+
+	started := make(chan struct{}, 1)
+	sEnd.Register(context.Background(), "long", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			resp.SetError(ctx.Err())
+		case <-time.After(5 * time.Second):
+			resp.SetData(nil)
+		}
+	})
+	waitForRemoteRPC()
+
+	callDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_, err := cEnd.Call(ctx, "long", cEnd.NewRequest(nil))
+		callDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	// Slam the client's transport once the handler is running.
+	cChaos.Kill()
+
+	select {
+	case err := <-callDone:
+		if err == nil {
+			t.Fatal("Call should have errored after transport kill")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Call did not return within 5s of transport kill")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); cEnd.Close() }()
+	go func() { defer wg.Done(); sEnd.Close() }()
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// E5 — fire 200 Calls, cancel them all at once. Every Call must return
+// ctx.Err or a peer error; no goroutine should be left blocked on the
+// in-flight packet wait. Verifies cancel propagates from client to
+// server handler context.
+func TestManySimultaneousRPCCancels(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	ln := harness.NewListener(t)
+	serverReady := make(chan struct{})
+	handlerStarted := make(chan struct{}, 1024)
+	handlerExits := make(chan struct{}, 1024)
+	serverEndCh := make(chan geminio.End, 1)
+	go func() {
+		end, err := ln.AcceptEnd()
+		if err != nil {
+			return
+		}
+		end.Register(context.Background(), "sleep", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+			handlerStarted <- struct{}{}
+			<-ctx.Done()
+			resp.SetError(ctx.Err())
+			handlerExits <- struct{}{}
+		})
+		serverEndCh <- end
+		close(serverReady)
+	}()
+
+	opts := client.NewEndOptions()
+	opts.SetWaitRemoteRPCs("sleep")
+	cEnd, err := client.NewEnd("tcp", ln.Addr().String(), opts)
+	if err != nil {
+		t.Fatalf("NewEnd: %v", err)
+	}
+	<-serverReady
+	sEnd := <-serverEndCh
+
+	const n = 50 // keep modest — 200 saturates the writeInCh and races cancel vs request arrival
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, err := cEnd.Call(rootCtx, "sleep", cEnd.NewRequest(nil))
+			errs[i] = err
+		}(i)
+	}
+
+	// Wait until all N handlers have started before cancelling. Cancelling
+	// a Call whose request packet has not yet reached the server is a
+	// separate scenario covered by E4; here we want a clean "cancel while
+	// server is genuinely running the handler" signal.
+	deadline := time.Now().Add(5 * time.Second)
+	var started int
+	for started < n && time.Now().Before(deadline) {
+		select {
+		case <-handlerStarted:
+			started++
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if started < n {
+		t.Fatalf("only %d/%d handlers started before timeout", started, n)
+	}
+
+	rootCancel() // cancel every in-flight Call at once
+	wg.Wait()
+
+	var nilCount int
+	for _, e := range errs {
+		if e == nil {
+			nilCount++
+		}
+	}
+	if nilCount > 0 {
+		t.Fatalf("%d Calls returned nil error after mass cancel", nilCount)
+	}
+
+	// Every handler must observe its ctx cancellation and exit.
+	deadline = time.Now().Add(3 * time.Second)
+	var exited int
+	for exited < n && time.Now().Before(deadline) {
+		select {
+		case <-handlerExits:
+			exited++
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if exited < n {
+		t.Fatalf("only %d/%d handlers exited after mass cancel", exited, n)
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 30)
+}

--- a/test/chaos/steady_state_test.go
+++ b/test/chaos/steady_state_test.go
@@ -1,0 +1,211 @@
+// Batch G — steady-state soak tests. Each pushes enough work through
+// the library to show whether goroutine counts or heap usage creep over
+// time. They are gated on -short so CI keeps moving; nightly runs pick
+// them up by running go test without -short.
+package chaos
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// gcAndSnapshot forces two collection cycles so any unreferenced
+// goroutine and heap memory has a fair chance to release before we
+// measure.
+func gcAndSnapshot() (goroutines int, heapBytes uint64) {
+	runtime.GC()
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return runtime.NumGoroutine(), m.HeapAlloc
+}
+
+// G1 — open-write-close 10 000 streams back-to-back, with one consumer
+// draining the peer end. At the end, goroutine count must be close to
+// the baseline and heap must not have grown dramatically.
+func TestGoroutineStableOverManyStreams(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak test; gated by -short")
+	}
+	harness.LogSilence(t)
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	// Drain every accepted stream.
+	stop := make(chan struct{})
+	var drain sync.WaitGroup
+	drain.Add(1)
+	go func() {
+		defer drain.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			type r struct {
+				s   geminio.Stream
+				err error
+			}
+			ch := make(chan r, 1)
+			go func() {
+				s, err := sEnd.AcceptStream()
+				ch <- r{s, err}
+			}()
+			select {
+			case res := <-ch:
+				if res.err != nil {
+					return
+				}
+				drain.Add(1)
+				go func(s geminio.Stream) {
+					defer drain.Done()
+					io.Copy(io.Discard, s)
+				}(res.s)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	// Warm up a few streams first so any one-shot init goroutines are
+	// already alive when we snapshot the baseline.
+	for i := 0; i < 5; i++ {
+		s, _ := cEnd.OpenStream()
+		s.Write([]byte("warm"))
+		s.Close()
+	}
+	time.Sleep(200 * time.Millisecond)
+	baselineG, baselineH := gcAndSnapshot()
+
+	const streams = 10_000
+	for i := 0; i < streams; i++ {
+		s, err := cEnd.OpenStream()
+		if err != nil {
+			t.Fatalf("OpenStream %d: %v", i, err)
+		}
+		s.Write([]byte("soak"))
+		s.Close()
+	}
+
+	// Give the consumer and the dismiss handshakes time to drain.
+	time.Sleep(1 * time.Second)
+	finalG, finalH := gcAndSnapshot()
+
+	if finalG > baselineG+30 {
+		t.Errorf("goroutine leak: baseline=%d final=%d over %d streams",
+			baselineG, finalG, streams)
+	}
+	// Heap: allow 25 MiB growth — arbitrary generous bound. Real leaks
+	// scale with iterations and blow past this easily.
+	if finalH > baselineH+25*1024*1024 {
+		t.Errorf("heap grew %d bytes over %d streams (baseline %d, final %d)",
+			finalH-baselineH, streams, baselineH, finalH)
+	}
+
+	close(stop)
+	cEnd.Close()
+	sEnd.Close()
+	drain.Wait()
+}
+
+// G2 — publish 100 000 small messages under at-most-once semantics and
+// verify the heap stays flat. Uses the default semantic (no ack
+// required), which is the cheapest and most leak-prone code path.
+func TestMemoryStableUnderMessageLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak test; gated by -short")
+	}
+	harness.LogSilence(t)
+
+	sEnd, cEnd, _, _ := helpers.NewChaosEndPair(t)
+
+	var received atomic.Int64
+	go func() {
+		for {
+			msg, err := sEnd.Receive(context.Background())
+			if err != nil {
+				return
+			}
+			msg.Done()
+			received.Add(1)
+		}
+	}()
+
+	// Warmup.
+	for i := 0; i < 100; i++ {
+		_ = cEnd.Publish(context.Background(), cEnd.NewMessage([]byte("w")))
+	}
+	time.Sleep(200 * time.Millisecond)
+	baselineG, baselineH := gcAndSnapshot()
+
+	const msgs = 100_000
+	for i := 0; i < msgs; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = cEnd.Publish(ctx, cEnd.NewMessage([]byte("soak")))
+		cancel()
+	}
+
+	// Wait for consumer to drain.
+	deadline := time.Now().Add(10 * time.Second)
+	for received.Load() < int64(msgs+100) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	finalG, finalH := gcAndSnapshot()
+
+	if finalG > baselineG+30 {
+		t.Errorf("goroutine leak: baseline=%d final=%d", baselineG, finalG)
+	}
+	if finalH > baselineH+50*1024*1024 {
+		t.Errorf("heap grew %d bytes over %d messages", finalH-baselineH, msgs)
+	}
+
+	cEnd.Close()
+	sEnd.Close()
+}
+
+// G3 — kill / reconnect the client End 20 times. Each cycle opens a
+// fresh End over a fresh TCP conn. Goroutine count at the end must be
+// steady.
+func TestKillRestartPeerManyTimes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak test; gated by -short")
+	}
+	harness.LogSilence(t)
+
+	baselineG, _ := gcAndSnapshot()
+
+	const cycles = 20
+	for i := 0; i < cycles; i++ {
+		sEnd, cEnd, _, cChaos := helpers.NewChaosEndPair(t)
+		s, err := cEnd.OpenStream()
+		if err != nil {
+			t.Fatalf("cycle %d OpenStream: %v", i, err)
+		}
+		s.Write([]byte("hello"))
+		cChaos.Kill()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cEnd.Close() }()
+		go func() { defer wg.Done(); sEnd.Close() }()
+		wg.Wait()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	finalG, _ := gcAndSnapshot()
+
+	if finalG > baselineG+30 {
+		t.Errorf("goroutine leak after %d kill cycles: baseline=%d final=%d",
+			cycles, baselineG, finalG)
+	}
+}

--- a/test/chaos/wire_chaos_test.go
+++ b/test/chaos/wire_chaos_test.go
@@ -1,0 +1,218 @@
+// Batch F — wire-level attacks. Malformed packets, corrupted bytes, and
+// oversized-length declarations. Each test sends crafted bytes through a
+// raw TCP dial or flips bits on an established connection; the server
+// must never crash, must reject obviously-invalid input, and must not
+// treat the trash as legitimate traffic.
+package chaos
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/singchia/geminio"
+	"github.com/singchia/geminio/server"
+	"github.com/singchia/geminio/test/chaos/helpers"
+	"github.com/singchia/geminio/test/harness"
+)
+
+// F1 — randomly flip bits on Read bytes during a live RPC workload. The
+// server must not panic; the connection may reset (which is fine) but
+// noise must never escalate into a crash.
+func TestWireBitFlip(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, sChaos, _ := helpers.NewChaosEndPair(t)
+
+	sEnd.Register(context.Background(), "echo", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		resp.SetData(req.Data())
+	})
+	time.Sleep(100 * time.Millisecond) // register propagation
+
+	// Light corruption on the server-side read path. 1 permille (0.1%) is
+	// enough to guarantee multiple flipped bytes across a burst of RPCs
+	// while still letting most traffic land.
+	sChaos.SetCorruptRate(1)
+
+	const calls = 100
+	var errs atomic.Int64
+	var okays atomic.Int64
+	for i := 0; i < calls; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		_, err := cEnd.Call(ctx, "echo", cEnd.NewRequest([]byte("ping")))
+		cancel()
+		if err != nil {
+			errs.Add(1)
+		} else {
+			okays.Add(1)
+		}
+	}
+	// Every Call returned something; the process is alive; that is the bar.
+	if okays.Load()+errs.Load() != calls {
+		t.Fatalf("lost calls: ok=%d err=%d total=%d", okays.Load(), errs.Load(), calls)
+	}
+
+	sChaos.SetCorruptRate(0)
+	cEnd.Close()
+	sEnd.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// F2 — raw TCP client declares a packet with PacketLen larger than the
+// server's DefaultMaxPacketSize. Server's conn.readPkt should discard
+// the oversized packet and either close the connection or resume; it
+// must not allocate the declared size.
+func TestOversizedPacketDeclaration(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	ln, err := server.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		end, err := ln.AcceptEnd()
+		accepted <- struct{}{}
+		if err == nil {
+			end.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	// Craft a 14-byte header with type=StreamPacket and PacketLen=500 MB.
+	// No payload follows; server must not hang on a 500 MB read or
+	// allocate that much memory — the size cap is 10 MB.
+	hdr := make([]byte, 14)
+	hdr[0] = 0x01                                                 // version
+	hdr[1] = 0x61                                                 // TypeStreamPacket
+	binary.BigEndian.PutUint64(hdr[2:10], 0xdeadbeefcafebabe)    // random id
+	binary.BigEndian.PutUint32(hdr[10:14], 500*1024*1024)         // 500 MB
+	if _, err := conn.Write(hdr); err != nil {
+		t.Fatalf("Write header: %v", err)
+	}
+
+	// Give the server a moment to process then drop us. AcceptEnd may
+	// have already returned with err; either way, progress is the bar.
+	select {
+	case <-accepted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not react to oversized-length packet within 3s")
+	}
+
+	conn.Close()
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// F3 — raw TCP client declares PacketLen=100 but sends only 10 bytes of
+// payload then closes. Server's io.ReadFull should return ErrUnexpectedEOF
+// and the read goroutine must exit cleanly.
+func TestTruncatedPacket(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	ln, err := server.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		end, err := ln.AcceptEnd()
+		accepted <- struct{}{}
+		if err == nil {
+			end.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	hdr := make([]byte, 14)
+	hdr[0] = 0x01
+	hdr[1] = 0x61 // StreamPacket
+	binary.BigEndian.PutUint64(hdr[2:10], 1)
+	binary.BigEndian.PutUint32(hdr[10:14], 100) // declares 100 bytes
+	// Write header + only 10 bytes body, then close.
+	conn.Write(hdr)
+	conn.Write(make([]byte, 10))
+	conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not react to truncated packet within 3s")
+	}
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}
+
+// F4 — heavy corruption (5%) on an already-handshaked connection. A
+// handshake completes cleanly; then we turn up corruption so subsequent
+// traffic is almost guaranteed to get mangled. End.Close must still
+// return; no goroutines may linger.
+func TestHeavyCorruptionDuringTraffic(t *testing.T) {
+	harness.LogSilence(t)
+	before := harness.TakeSnapshot()
+
+	sEnd, cEnd, sChaos, cChaos := helpers.NewChaosEndPair(t)
+
+	// Run a few normal ops to confirm the link is healthy.
+	sEnd.Register(context.Background(), "echo", func(ctx context.Context, req geminio.Request, resp geminio.Response) {
+		resp.SetData(req.Data())
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	if _, err := cEnd.Call(ctx, "echo", cEnd.NewRequest([]byte("warmup"))); err != nil {
+		cancel()
+		t.Fatalf("warmup Call: %v", err)
+	}
+	cancel()
+
+	// Now sabotage both directions heavily.
+	sChaos.SetCorruptRate(50) // 5%
+	cChaos.SetCorruptRate(50)
+
+	// Fire more RPCs. Some will succeed (lucky, no corrupted bytes landed
+	// on a critical field), many will error. We only assert the process
+	// survives and Close returns within a bounded window.
+	for i := 0; i < 50; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		_, _ = cEnd.Call(ctx, "echo", cEnd.NewRequest([]byte("x")))
+		cancel()
+	}
+	sChaos.SetCorruptRate(0)
+	cChaos.SetCorruptRate(0)
+
+	done := make(chan struct{})
+	go func() {
+		cEnd.Close()
+		sEnd.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(closeDeadline):
+		t.Fatalf("Close hung under heavy corruption (>%s)", closeDeadline)
+	}
+	time.Sleep(500 * time.Millisecond)
+	harness.AssertNoLeak(t, before, 20)
+}


### PR DESCRIPTION
## Summary

Chaos testing exercise targeting every break-point the existing test suite skips: peer killed mid-stream, half-open links, handler panics, handler-blocks-forever, mass concurrent RPC cancel. Designing the tests to actively sabotage the library surfaced **four real RPC-path bugs** that would each take down a production peer in different ways. Fixes + new test suite land together.

## Four library bugs fixed

1. **Handler panic crashes the whole End** — `stream.doRPC` had no `defer recover()` around the user handler goroutine. One buggy handler and the process dies.
2. **RPC cancel never reaches the handler on the server** — three nested bugs:
   - `handleInRequestPacket` only populated `rpcCancels` when the peer sent a deadline; `WithCancel`-only requests left ctx as `context.Background`, so the server cancel lookup silently missed every time.
   - `handleOut` had no switch case for `*packet.RequestCancelPacket`, so the cancel packet landed on the default branch and was dropped without ever hitting the wire.
   - `packet.Decode` / `DecodeFromReader` both missed `TypeRequestCancelPacket` (0x73), so even if a cancel packet made it on the wire it was rejected as `ErrUnsupportedPacket`.

Net effect before this PR: any `cEnd.Call(ctx, ...)` whose ctx was cancelled (not deadlined) silently leaked a server-side handler goroutine forever.

Also fixes a race the `-race` detector flagged along the way: `dialogue.fini` no longer nils `writeOutCh`, which raced `writePkt`'s initial range read without any benefit (senders already check `ctx.Done`).

## 15 new chaos tests

Organised under `test/chaos/` by attack vector.

Batch A — transport sabotage (`kill_peer_test.go`):
- TestPeerKilledMidWrite — peer killed while server is streaming a 4 MB payload.
- TestPeerKilledMidRead — peer killed while client Read is blocked.
- TestHalfOpenSendOnly / TestHalfOpenRecvOnly — one direction silently swallowed.
- TestNetworkBlackhole — both directions drop, TCP still alive.

Batch B — lifecycle edges (`dismiss_chaos_test.go`):
- TestKillPeerDuringDismiss — kill in the middle of the 4-way dismiss.
- TestOpenStreamDuringEndClose — OpenStream racing End.Close.
- TestReentrantClose — 50 concurrent Close calls on one stream.
- TestCloseReadRaceOver100Iterations — rapid open/write/close × 100.
- TestEndCloseWithInflightRPCs — slam End.Close while 10 RPCs are in flight.

Batch E — RPC sabotage (`rpc_chaos_test.go`):
- TestHandlerPanics — handler panic, End must survive, second Call still works.
- TestHandlerBlocksForever — handler blocks on ctx.Done, client ctx cancel must exit it.
- TestBiRPCDeadlockAvoidance — A handler calls B, B handler calls A.
- TestRPCCancelThroughReconnect — kill transport mid-Call.
- TestManySimultaneousRPCCancels — 50 Calls, cancel all at once, every handler exits.

Helper — `test/chaos/helpers/chaosconn.go`. A `net.Conn` wrapper with runtime-configurable sabotage: DropRate, CorruptRate, Delay, HalfClose(dir), Blackhole(), Kill(). Plus `NewChaosEndPair(t)` to splice chaos into server.NewEndWithConn + client.NewEndWithDialer.

## Test plan

- `go test ./test/chaos/...` — 15/15 pass. Total runtime around 160 s, dominated by the 94 s TestHalfOpenSendOnly waiting out the heartbeat timeout.
- `go test -race ./test/chaos/...` — chaos suite race-clean after the fini cleanup. The unrelated go-timer/v2 race still trips under parallel load on ./application/... packages; that is pre-existing and was already scoped out of test.yml Unit Tests in #111.
- Full regression: go test ./application/... ./multiplexer/... ./packet/... ./test/unit/ ./test/integration/ ./test/regression/ ./test/e2e/ — all green.
